### PR TITLE
Update microtime dependency to one compatible with Xcode CLI Tools v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "wd": "0.0.32"
   },
   "optionalDependencies": {
-    "microtime": "2.1.2"
+    "microtime": "2.1.8"
   },
   "files": [
     "build-out/wtf_node_js_compiled.js",


### PR DESCRIPTION
I tried compiling this project and couldn't get through the steps. I don't even know if anyone uses this project anymore.

This is in service of unblocking @jonathanswenson and others who are experiencing problems compiling Helltool dependencies under XCode v10.